### PR TITLE
Add changelog template and initial entry

### DIFF
--- a/CHANGELOG.csv
+++ b/CHANGELOG.csv
@@ -1,0 +1,2 @@
+Ticket,Date,Time,Author,Description,Files Affected,Notes
+CL-001,2025-06-17,22:00,LinDon Harris,"Initial clone of LegalCaseAIApp by Dominic Dawes to create new repository legalcaseaiapp-lhcodex.","All files","Source repo was LegalCaseAIApp (Dominic Dawes)."

--- a/CHANGELOG_INSTRUCTIONS.md
+++ b/CHANGELOG_INSTRUCTIONS.md
@@ -1,0 +1,25 @@
+# Change Log Update Guide
+
+This repository tracks updates in `CHANGELOG.csv`. Each row is a JIRA-style entry with detailed context.
+
+## CSV Columns
+- **Ticket**: Unique identifier, e.g., `CL-###`.
+- **Date**: Date of change in `YYYY-MM-DD` format.
+- **Time**: Time of change (24h) in `HH:MM` format.
+- **Author**: Person making the change.
+- **Description**: Rich text summary of the change.
+- **Files Affected**: Key files or paths modified.
+- **Notes**: Any additional comments or context.
+
+## How to Add an Entry
+1. Append a new line to `CHANGELOG.csv`.
+2. Use the next sequential ticket ID (`CL-002`, `CL-003`, etc.).
+3. Fill out each column. Use quotes if your text contains commas.
+4. Commit the updated `CHANGELOG.csv` with a descriptive message.
+
+Example entry:
+```
+CL-002,2025-06-18,09:30,LinDon Harris,"Updated README with setup steps","README.md",""
+```
+
+Keep the log sorted by ticket number to maintain history.


### PR DESCRIPTION
## Summary
- create a CSV-based `CHANGELOG.csv` containing cloning details
- add `CHANGELOG_INSTRUCTIONS.md` explaining how to update the log

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_e_68521ee4aff08326a8d3c9fdecc5adc2