### PR TITLE
CL-004: fix instructions link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS Instructions for legalcaseaiapp-lhcodex
+
+This repository welcomes contributions from automated agents. To keep the history clear and reproducible, follow these rules on **every** code change and pull request.
+
+## Changelog Policy
+ - For each pull request, append a new line to `CHANGELOG.csv` using the format described in [CHANGELOG_INSTRUCTIONS.md](CHANGELOG_INSTRUCTIONS.md).
+- The ticket ID must be unique and sequential (e.g., `CL-003`, `CL-004`).
+- Reference the ticket ID in your commit message prefix and in the pull request title.
+- Keep `CHANGELOG.csv` sorted by ticket number and never modify existing rows.
+
+## Development Workflow
+1. Make your code changes.
+2. Update `CHANGELOG.csv` with a new row describing the change.
+3. Run `pytest` to execute all tests. Resolve any failures.
+4. Commit your code **and** the updated changelog entry with a descriptive message starting with the ticket ID.
+5. Open a pull request referencing the same ticket ID. Summarize the change and mention the affected files.
+
+## Code Style
+- Use Python 3.12 features where appropriate.
+- Follow PEP8 style conventions and format code with `black` (line length 88) if available.
+
+By committing to this repository you agree to follow these instructions so that all changes remain transparent and traceable.

--- a/CHANGELOG.csv
+++ b/CHANGELOG.csv
@@ -1,3 +1,5 @@
 Ticket,Date,Time,Author,Description,Files Affected,Notes
 CL-001,2025-06-17,22:00,LinDon Harris,"Initial clone of LegalCaseAIApp by Dominic Dawes to create new repository legalcaseaiapp-lhcodex.","All files","Source repo was LegalCaseAIApp (Dominic Dawes)."
 CL-002,2025-06-18,02:58,LinDon Harris,"Add product spec doc","dev guides/product_spec.md",""
+CL-003,2025-06-18,03:08,LinDon Harris,"Add AGENTS file with commit guidelines","AGENTS.md",""
+CL-004,2025-06-18,03:16,LinDon Harris,"Clarify changelog instructions link in AGENTS","AGENTS.md",""


### PR DESCRIPTION
## Summary
- clarify link to changelog instructions in AGENTS.md
- log the update in CHANGELOG.csv

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: DeepSeek credentials or 'six' missing)*

------
https://chatgpt.com/codex/tasks/task_e_68522ca3f03c8326b84fb2f80a64fa3d