### PR TITLE
CL-006 add manual task ticketing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,9 @@ This repository welcomes contributions from automated agents. To keep the histor
 - Follow PEP8 style conventions and format code with `black` (line length 88) if available.
 
 By committing to this repository you agree to follow these instructions so that all changes remain transparent and traceable.
+
+## Manual Tasks Log
+ - When a change requires human intervention (environment setup, migrations, etc.) add an entry to `dev guides/manual_tasks.csv`.
+ - The CSV columns are `ticket`, `title`, `description`, `affected_files`, and `timestamp`.
+ - Tickets must be sequential (`MT-001`, `MT-002`, and so on).
+ - Delete a row once the manual task has been completed.

--- a/CHANGELOG.csv
+++ b/CHANGELOG.csv
@@ -3,3 +3,5 @@ CL-001,2025-06-17,22:00,LinDon Harris,"Initial clone of LegalCaseAIApp by Domini
 CL-002,2025-06-18,02:58,LinDon Harris,"Add product spec doc","dev guides/product_spec.md",""
 CL-003,2025-06-18,03:08,LinDon Harris,"Add AGENTS file with commit guidelines","AGENTS.md",""
 CL-004,2025-06-18,03:16,LinDon Harris,"Clarify changelog instructions link in AGENTS","AGENTS.md",""
+CL-005,2025-06-18,03:32,LinDon Harris,"Add manual tasks log instructions","AGENTS.md;dev guides/manual_tasks.csv",""
+CL-006,2025-06-18,03:40,LinDon Harris,"Add ticket field to manual tasks log and record first manual task","AGENTS.md;dev guides/manual_tasks.csv",""

--- a/dev guides/manual_tasks.csv
+++ b/dev guides/manual_tasks.csv
@@ -1,0 +1,2 @@
+ticket,title,description,affected_files,timestamp
+MT-001,Configure environment variables,"Set OPENAI_API_KEY, SUPABASE_PROJECT_URL, SUPABASE_SERVICE_ROLE_KEY, AWS credentials, and other environment variables in a .env file","utils/*;tasks/*;test/api_health.py",2025-06-18T03:40:10Z


### PR DESCRIPTION
## Summary
- clarify manual tasks log instructions
- include ticket in manual_tasks.csv and record environment setup task
- log the change in CHANGELOG.csv

## Testing
- `pytest -q` *(fails: DeepSeek credentials or base URL not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6852316df42c8326bc89296bd9355a8a